### PR TITLE
separate nightly

### DIFF
--- a/.github/workflows/beta_testing.yaml
+++ b/.github/workflows/beta_testing.yaml
@@ -1,8 +1,8 @@
-name: Nightly
-# On every Sunday at 02:03
+name: Beta
+# On every Sunday at 01:03
 on:
   schedule:
-    - cron: '3 2 * * 0'
+    - cron: '3 1 * * 0'
   workflow_dispatch:
 
 jobs:
@@ -17,11 +17,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-nightly
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-beta
       - name: Install cargo
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: beta
           profile: minimal
           components: rustfmt, clippy
           override: true
@@ -46,13 +46,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-nightly
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-beta
       - name: Install required libs (Ubuntu)
         run: sudo apt-get install libxkbcommon-dev
       - name: Install cargo
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: beta
           profile: minimal
           override: true
       - name: Run rust test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Stable Rust version build status:
 [![Build Status](https://github.com/naokiri/cskk/workflows/Test/badge.svg)](https://github.com/naokiri/cskk/actions)
 
 Beta and Nightly Rust version build status:
-[![Build Status (Beta or Nightly)](https://github.com/naokiri/cskk/workflows/Beta_Nightly/badge.svg)](https://github.com/naokiri/cskk/actions)
+[![Build Status (Beta or Nightly)](https://github.com/naokiri/cskk/workflows/Beta/badge.svg)](https://github.com/naokiri/cskk/actions)
 
 [English version](https://github.com/naokiri/cskk/blob/master/README.en.md)
 


### PR DESCRIPTION
It is too unstable to show the build status on top and cannot make the fix work on stable.