### PR TITLE
Fix assets installation issue

### DIFF
--- a/cskk/Cargo.toml
+++ b/cskk/Cargo.toml
@@ -60,7 +60,7 @@ description = "SKK (Simple Kana Kanji) henkan library"
 
 [package.metadata.capi.install.data]
 subdirectory = "libcskk"
-asset = [{ from = "assets/**/*" }]
+asset = [{ from = "../assets/**/*" }]
 
 [profile.release]
 strip = "debuginfo"
@@ -86,4 +86,3 @@ assets = [["../assets/**/*", "usr/local/share/libcskk", "644"],
     ["target/release/libcskk.a", "usr/local/lib/cskk/", "644"],
     ["target/release/cskk.pc", "usr/local/lib/pkgconfig/", "644"],
     ["target/release/libcskk.h", "usr/local/include/cskk/", "644"]]
-


### PR DESCRIPTION
This PR is a recreation of #284.

---

Fixed an issue where assets were no longer being installed from v3.2.0.

Before this fix:
```console
% cargo cinstall --prefix=/tmp/cskk -vv
...
    Finished `release` profile [optimized] target(s) in 0.41s
note: PKG_CONFIG_PATH="/home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release"
  Installing pkg-config file
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/cskk.pc to /tmp/cskk/lib/pkgconfig/cskk.pc
  Installing header file
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/libcskk.h to /tmp/cskk/include/cskk/libcskk.h
  Installing static library
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/libcskk.a to /tmp/cskk/lib/cskk/libcskk.a
  Installing shared library
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/libcskk.so to /tmp/cskk/lib/cskk/libcskk.so.3.2.0
```

After:
```console
% cargo cinstall --prefix=/tmp/cskk -vv
...
    Finished `release` profile [optimized] target(s) in 7.11s
    Building pkg-config files
    Building header file using cbindgen
  Populating uninstalled header directory
note: PKG_CONFIG_PATH="/home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release"
  Installing pkg-config file
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/cskk.pc to /tmp/cskk/lib/pkgconfig/cskk.pc
  Installing header file
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/libcskk.h to /tmp/cskk/include/cskk/libcskk.h
  Installing data file
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/cskk/../assets/README.rules to /tmp/cskk/share/libcskk/README.rules
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/cskk/../assets/rule/ascii_form.toml to /tmp/cskk/share/libcskk/rule/ascii_form.toml
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/cskk/../assets/rule/kana_form.toml to /tmp/cskk/share/libcskk/rule/kana_form.toml
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/cskk/../assets/rules/azik/rule.toml to /tmp/cskk/share/libcskk/rules/azik/rule.toml
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/cskk/../assets/rules/default/rule.toml to /tmp/cskk/share/libcskk/rules/default/rule.toml
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/cskk/../assets/rules/metadata.toml to /tmp/cskk/share/libcskk/rules/metadata.toml
  Installing static library
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/libcskk.a to /tmp/cskk/lib/cskk/libcskk.a
  Installing shared library
     Copying /home/taiki/dev/src/github.com/naokiri/cskk/target/x86_64-unknown-linux-gnu/release/libcskk.so to /tmp/cskk/lib/cskk/libcskk.so.3.2.0
```