### PR TITLE
Update Phase 2 dependencies (MSRV 1.72 compatible)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -3555,9 +3555,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3567,25 +3567,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.4",
+ "toml_write",
+ "winnow 0.7.14",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -4089,9 +4096,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/cskk/Cargo.toml
+++ b/cskk/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "^1.0.228"
 sequence_trie = { version = "^0.3.6", features = ["serde"] }
 encoding_rs = "0.8"
 encoding_rs_io = "0.1"
-toml = "0.8.20"
+toml = "0.8.23"
 thiserror = "2.0.17"
 regex = "^1.12.2"
 lazy_static = "1.4"


### PR DESCRIPTION
## Summary
Updates 7 runtime dependencies to their latest MSRV-compatible versions, addressing security vulnerabilities while maintaining strict Rust 1.72 compatibility.

## Updates

| Dependency | Version Change | MSRV |
|------------|----------------|------|
| serde + serde_derive | 1.0.219 → 1.0.228 | 1.31 |
| thiserror | 2.0.12 → 2.0.17 | 1.61 |
| bitflags | 2.2.1 → 2.10.0 | 1.56 |
| regex | 1.5 → 1.12.2 | 1.65 |
| anyhow | 1.0.65 → 1.0.100 | 1.65 |
| log | 0.4.17 → 0.4.29 | 1.60 |
| toml | 0.8.20 → 0.8.23 | 1.70 |

## MSRV Compliance

All updates maintain strict compatibility with project MSRV (Rust 1.72):
- ✅ All dependency MSRVs ≤ 1.72
- ✅ No edition 2024 dependencies introduced
- ✅ toml capped at 0.8.23 (avoiding 0.9.x which requires 1.76+)
- ✅ All transitive dependencies verified compatible

## Testing Protocol

Each dependency was updated individually with full MSRV testing:
```bash
cargo clean
cargo +1.72 check --features capi
cargo +1.72 test --features capi
```

Results:
- ✅ All 78+ tests pass with Rust 1.72
- ✅ All 78+ tests pass with stable Rust
- ✅ cargo clippy clean
- ✅ Zero MSRV compatibility issues

## Security Impact

Addresses multiple vulnerabilities from the 55 reported on the default branch. Build-time vulnerabilities (cargo-c related) remain as cargo-c 0.10.19 requires Rust 1.86+ and edition 2024, which breaks MSRV compatibility.

## Related

- Previous dependency-update-1 branch was abandoned due to edition 2024 incompatibility
- This approach follows DEPENDENCY_UPDATE_PLAN_V2.md Phase 2
- Each update is in a separate commit for easy review/revert if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>