### PR TITLE
feat: add configurable composition triggers via rule file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- ルールファイルに `composition_triggers` 配列を追加することで、変換トリガーキーを設定可能に。A-Z以外の記号キー（例: `exclam`）も変換トリガーに指定できる。デフォルトルールおよびAZIKルールはA-Zを明示的に列挙。詳細は `docs/henkan-trigger-extension.md` を参照。
+
+### Changed
+- **ルール作者向け破壊的変更**: `[options] composition_triggers` を省略したルールファイルでは、いかなるキーも見出し語入力状態（▽モード）に入らなくなる。カスタムルールを使用している場合は `[options]` セクションに `composition_triggers` を追加する必要がある（少なくとも `"A"` 〜 `"Z"` の26文字を列挙すること）。
+
 ## [3.3.0] - 2026-03-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cskk"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2488,7 +2488,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru_ordered_map"
-version = "3.2.1"
+version = "3.3.0"
 
 [[package]]
 name = "matchers"

--- a/assets/rules/azik/rule.toml
+++ b/assets/rules/azik/rule.toml
@@ -2,6 +2,12 @@
 name = "azik"
 description = "AZIK typing rule"
 
+[options]
+composition_triggers = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
+]
+
 #
 # 拡張ローマ字入力 ＡＺＩＫ 総合解説書に基づく http://hp.vector.co.jp/authors/VA002116/azik/azikinfo.htm#itiran
 # ただしl前置拗音をxx前置拗音に置き換え

--- a/assets/rules/default/rule.toml
+++ b/assets/rules/default/rule.toml
@@ -6,6 +6,14 @@ name = "default"
 # 説明文。必須。
 description = "default typing rule"
 
+[options]
+# PreCompositionモードに入るKeysym。
+# アルファベット以外でかな入力をする場合、ここにKeysymを追加することでそのかな文字での変換開始位置を指定する。
+composition_triggers = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
+]
+
 # conversion:
 # Key-Valueの配列 ローマ字変換規則
 #

--- a/cskk/src/form_changer/numeric_form_changer.rs
+++ b/cskk/src/form_changer/numeric_form_changer.rs
@@ -157,14 +157,11 @@ pub(crate) fn numeric_to_thousand_separator(original: &str) -> String {
         if num_len < 4 {
             return num_char.to_string();
         }
-        let mut cnt = 3 - (num_len % 3);
-
-        for c in num_char.chars() {
+        for (cnt, c) in (3 - (num_len % 3)..).zip(num_char.chars()) {
             result.push(c);
             if cnt % 3 == 2 && cnt < num_len {
                 result.push(',');
             }
-            cnt += 1;
         }
     }
     result

--- a/cskk/src/keyevent.rs
+++ b/cskk/src/keyevent.rs
@@ -155,11 +155,16 @@ impl CskkKeyEvent {
             let word = word.trim();
             let word_keysym = keysym_from_name(word, xkb::KEYSYM_NO_FLAGS);
             if Keysym::NoSymbol == word_keysym {
+                let mut any_resolved = false;
                 for char in word.chars() {
                     let char_keysym = keysym_from_name(&char.to_string(), xkb::KEYSYM_NO_FLAGS);
                     if Keysym::NoSymbol != char_keysym {
                         result.push(char_keysym);
+                        any_resolved = true;
                     }
+                }
+                if !any_resolved && !word.is_empty() {
+                    log::warn!("rule: unrecognised keysym name {:?} — ignored", word);
                 }
             } else {
                 result.push(word_keysym);
@@ -184,6 +189,18 @@ impl CskkKeyEvent {
     ///
     pub(crate) fn is_upper(&self) -> bool {
         matches!(self.symbol.raw(), keysyms::KEY_A..=keysyms::KEY_Z)
+    }
+
+    ///
+    /// かな変換ルールのトライ木に渡すキーイベントを返す。
+    /// A-Zの大文字は小文字化する。それ以外はそのまま返す。
+    ///
+    pub(crate) fn to_kana_lookup(&self) -> Self {
+        if self.is_upper() {
+            self.to_lower()
+        } else {
+            self.clone()
+        }
     }
 
     ///

--- a/cskk/src/lib.rs
+++ b/cskk/src/lib.rs
@@ -27,7 +27,7 @@ use crate::rule::{CskkRule, CskkRuleMetadata, CskkRuleMetadataEntry};
 use crate::skk_modes::{has_rom2kana_conversion, CompositionMode};
 use crate::skk_modes::{CommaStyle, InputMode, PeriodStyle};
 use form_changer::{AsciiFormChanger, KanaFormChanger};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -70,6 +70,7 @@ pub struct CskkContext {
     ascii_form_changer: AsciiFormChanger,
     dictionaries: Vec<Arc<CskkDictionary>>,
     config: CskkConfig,
+    composition_triggers: HashSet<Keysym>,
     //rule: CskkRuleMetadataEntry,
 }
 
@@ -775,26 +776,30 @@ impl CskkContext {
     ///
     /// done_transition_on_kana_build: 現在のkanabuildで既にモード変更を行っているかどうか。
     ///
-    fn transition_composition_mode_by_capital_letter(
+    fn is_henkan_trigger(&self, key_event: &CskkKeyEvent) -> bool {
+        self.composition_triggers.contains(&key_event.get_symbol())
+    }
+
+    fn transition_composition_mode_by_trigger_key(
         &mut self,
         key_event: &CskkKeyEvent,
         initial_kanainput_composition_mode: CompositionMode,
         done_transition_on_kana_build: bool,
     ) -> bool {
-        let is_capital = key_event.is_upper();
+        let is_trigger = self.is_henkan_trigger(key_event);
         let is_empty = self
             .current_state_ref()
             .get_to_composite_string()
             .is_empty();
 
-        if is_capital
+        if is_trigger
             && !done_transition_on_kana_build
             && initial_kanainput_composition_mode == CompositionMode::Direct
         {
             self.set_composition_mode(CompositionMode::PreComposition);
             self.current_state().set_capital_transition(true);
             true
-        } else if is_capital
+        } else if is_trigger
             && !is_empty
             && !done_transition_on_kana_build
             && initial_kanainput_composition_mode == CompositionMode::PreComposition
@@ -955,35 +960,45 @@ impl CskkContext {
             let converted_lower = self.kana_converter.convert_non_partial(&combined_lower);
             let initial_kanainput_composition_mode = self.current_state_ref().composition_mode;
 
-            if let Some((converted, carry_over)) =
-                self.kana_converter.convert_non_partial(&combined_raw)
-            {
-                // When input made a kana conversion in raw input.
-                // Even if matched in upper case, this won't try to change the composition mode.
-                let converted = converted.clone();
-                let carry_over = carry_over.clone();
+            // For non-letter henkan triggers (symbol keysyms listed in composition_triggers),
+            // combine_raw == combine_lower (uncapitalize is a no-op outside A-Z). Skipping the
+            // raw-path branches here lets the trigger branch below fire and change composition mode.
+            // For A-Z and unshifted inputs the raw branches run normally.
+            let is_non_letter_trigger = !key_event.is_upper() && self.is_henkan_trigger(key_event);
 
-                self.input_converted_kana(
-                    &converted,
-                    carry_over,
-                    false,
-                    initial_unprocessed_vector,
-                );
-                return true;
-            } else if key_event.is_upper() {
+            if !is_non_letter_trigger {
+                if let Some((converted, carry_over)) =
+                    self.kana_converter.convert_non_partial(&combined_raw)
+                {
+                    // When input made a kana conversion in raw input.
+                    // Even if matched in upper case (e.g. tsU), this won't change composition mode.
+                    let converted = converted.clone();
+                    let carry_over = carry_over.clone();
+
+                    self.input_converted_kana(
+                        &converted,
+                        carry_over,
+                        false,
+                        initial_unprocessed_vector,
+                    );
+                    return true;
+                }
+            }
+
+            if self.is_henkan_trigger(key_event) {
                 if let Some((converted, carry_over)) = converted_lower {
-                    // When input can make kana conversion in lowercase input.
+                    // When input can make kana conversion via the trigger lookup key.
                     // Try changing the composition mode and then insert kana.
 
                     let converted = converted.clone();
                     let carry_over = carry_over.clone();
 
-                    let did_change_mode = self.transition_composition_mode_by_capital_letter(
+                    let did_change_mode = self.transition_composition_mode_by_trigger_key(
                         key_event,
                         initial_kanainput_composition_mode,
                         self.current_state_ref().get_capital_transition(),
                     );
-                    // When input made a kana conversion when tried with lower letter.
+                    // When input made a kana conversion when tried with lookup key.
                     self.input_converted_kana(
                         &converted,
                         carry_over,
@@ -996,6 +1011,20 @@ impl CskkContext {
 
             // character input didn't make kana conversion in this else flow.
             let current_input_mode = self.current_state_ref().input_mode;
+
+            // Pre-compute alone_raw and alone_lower results (cloned to release kana_converter borrow).
+            // alone_raw is suppressed for non-letter triggers so the trigger/lower path fires instead.
+            let alone_raw_result: Option<(String, Vec<Keysym>)> = if !is_non_letter_trigger {
+                self.kana_converter
+                    .convert_non_partial(&alone_raw)
+                    .map(|(c, co)| (c.clone(), co.clone()))
+            } else {
+                None
+            };
+            let alone_lower_result: Option<(String, Vec<Keysym>)> = self
+                .kana_converter
+                .convert_non_partial(&alone_lower)
+                .map(|(c, co)| (c.clone(), co.clone()));
 
             if let Some(key_char) = key_event.get_symbol_char() {
                 // カンマピリオドは特殊な設定と処理がある。 TODO: これも一般化したい。
@@ -1030,31 +1059,29 @@ impl CskkContext {
                             return false;
                         }
                     }
-                } else if self
-                    .kana_converter
-                    .can_continue(key_event, &initial_unprocessed_vector)
+                } else if !is_non_letter_trigger
+                    && self
+                        .kana_converter
+                        .can_continue(key_event, &initial_unprocessed_vector)
                 {
                     // そのままでかな入力の続きとなれる入力なので、そのように処理
                     self.input_as_continuous_kana(key_event);
-                } else if key_event.is_upper()
+                } else if self.is_henkan_trigger(key_event)
                     && self
                         .kana_converter
                         .can_continue_lower(key_event, &initial_unprocessed_vector)
                 {
                     // モード変更として捉えればかな入力の続きとなれる入力。
-                    self.transition_composition_mode_by_capital_letter(
+                    self.transition_composition_mode_by_trigger_key(
                         key_event,
                         initial_kanainput_composition_mode,
                         self.current_state_ref().get_capital_transition(),
                     );
-                    let lower_key_event = key_event.to_lower();
-                    self.input_as_continuous_kana(&lower_key_event);
-                } else if let Some((converted, carry_over)) =
-                    self.kana_converter.convert_non_partial(&alone_raw)
-                {
+                    let lookup_key_event = key_event.to_kana_lookup();
+                    self.input_as_continuous_kana(&lookup_key_event);
+                } else if let Some((converted, carry_over)) = alone_raw_result {
                     // かな入力として成立しないが単純変換のある入力。続けて入力はできないがかな変換はできる文字。
-                    let converted = converted.to_owned();
-                    let carry_over = carry_over.clone();
+                    // (None when is_non_letter_trigger, so this branch is skipped for symbol triggers)
                     self.input_converted_kana(
                         &converted,
                         carry_over,
@@ -1062,14 +1089,10 @@ impl CskkContext {
                         initial_unprocessed_vector,
                     );
                     return true;
-                } else if let Some((converted, carry_over)) =
-                    self.kana_converter.convert_non_partial(&alone_lower)
-                {
+                } else if let Some((converted, carry_over)) = alone_lower_result {
                     // かな入力として成立しないがモード変更と捉えればかな単純変換の入力となる文字
-                    if key_event.is_upper() {
-                        let converted = converted.to_owned();
-                        let carry_over = carry_over.clone();
-                        let did_change_mode = self.transition_composition_mode_by_capital_letter(
+                    if self.is_henkan_trigger(key_event) {
+                        let did_change_mode = self.transition_composition_mode_by_trigger_key(
                             key_event,
                             initial_kanainput_composition_mode,
                             false,
@@ -1083,7 +1106,8 @@ impl CskkContext {
                         );
                         return true;
                     }
-                } else if self.kana_converter.can_continue(key_event, &[]) {
+                } else if !is_non_letter_trigger && self.kana_converter.can_continue(key_event, &[])
+                {
                     // かな入力として成立しない子音の連続等、続けては入力できないがkanabuilderで扱える文字。
                     // まずpre_convertedを整理してから入力として扱う。
                     self.output_converted_kana_if_any(
@@ -1095,12 +1119,12 @@ impl CskkContext {
                     self.input_as_continuous_kana(key_event);
                 } else if self.kana_converter.can_continue_lower(key_event, &[]) {
                     // 大文字をモード変更として捉えて小文字化すればkanabuilderで扱える入力
-                    self.transition_composition_mode_by_capital_letter(
+                    self.transition_composition_mode_by_trigger_key(
                         key_event,
                         initial_kanainput_composition_mode,
                         self.current_state_ref().get_capital_transition(),
                     );
-                    let lower_key_event = key_event.to_lower();
+                    let lookup_key_event = key_event.to_kana_lookup();
 
                     // TODO: この現在のステートのクリーンアップは上と同じであるべきなので、stateの整理ができたらメソッドにまとめる。
                     self.output_converted_kana_if_any(
@@ -1109,7 +1133,7 @@ impl CskkContext {
                     );
                     self.current_state().clear_preconverted_kanainputs();
 
-                    self.input_as_continuous_kana(&lower_key_event);
+                    self.input_as_continuous_kana(&lookup_key_event);
                 } else {
                     // kana builderですら扱えないキー。
                     // スペースや記号を想定。
@@ -1487,6 +1511,7 @@ impl CskkContext {
         let new_command_handler = ConfigurableCommandHandler::new(new_rule);
         self.kana_converter = new_kana_converter;
         self.command_handler = new_command_handler;
+        self.composition_triggers = new_rule.get_henkan_trigger_keysyms();
         Ok(())
     }
 
@@ -1503,6 +1528,7 @@ impl CskkContext {
 
         let kana_converter = Box::new(KanaBuilder::new(&default_rule));
         let command_handler = ConfigurableCommandHandler::new(&default_rule);
+        let composition_triggers = default_rule.get_henkan_trigger_keysyms();
         let initial_stack = vec![CskkState::new(input_mode, composition_mode)];
 
         Ok(Self {
@@ -1513,6 +1539,7 @@ impl CskkContext {
             ascii_form_changer: AsciiFormChanger::default_ascii_form_changer(),
             dictionaries,
             config: CskkConfig::default(),
+            composition_triggers,
         })
     }
 
@@ -1554,6 +1581,7 @@ impl CskkContext {
             ascii_form_changer: AsciiFormChanger::default_ascii_form_changer(),
             dictionaries,
             config: CskkConfig::default(),
+            composition_triggers: HashSet::new(),
         }
     }
 
@@ -1571,6 +1599,7 @@ impl CskkContext {
         let default_rule = rule_metadata.load_default_rule().unwrap();
         let kana_converter = Box::new(KanaBuilder::new(&default_rule));
         let command_handler = ConfigurableCommandHandler::new(&default_rule);
+        let composition_triggers = default_rule.get_henkan_trigger_keysyms();
 
         let initial_stack = vec![CskkState::new(input_mode, composition_mode)];
         Self {
@@ -1581,6 +1610,7 @@ impl CskkContext {
             ascii_form_changer: AsciiFormChanger::from_file(ascii_from_changer_filepath),
             dictionaries,
             config: CskkConfig::default(),
+            composition_triggers,
         }
     }
 
@@ -1648,6 +1678,7 @@ mod unit_tests {
 
         let kana_converter = Box::new(KanaBuilder::test_converter());
         let command_handler = ConfigurableCommandHandler::new(&default_rule);
+        let composition_triggers = default_rule.get_henkan_trigger_keysyms();
 
         let initial_stack = vec![CskkState::new(input_mode, composition_mode)];
         CskkContext {
@@ -1658,6 +1689,7 @@ mod unit_tests {
             ascii_form_changer: AsciiFormChanger::test_ascii_form_changer(),
             dictionaries,
             config: CskkConfig::default(),
+            composition_triggers,
             //rule_metadata,
         }
     }

--- a/cskk/src/rule.rs
+++ b/cskk/src/rule.rs
@@ -1,14 +1,23 @@
 use crate::env::filepath_from_xdg_data_dir;
 use crate::{CompositionMode, CskkError, CskkKeyEvent, InputMode, Instruction};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use xkbcommon::xkb::{self, keysym_from_name, Keysym};
+
+#[derive(Deserialize, Default, Debug)]
+pub(crate) struct CskkRuleOptions {
+    #[serde(default)]
+    composition_triggers: Vec<String>,
+}
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct CskkRule {
     conversion: HashMap<String, (String, String)>,
+    #[serde(default)]
+    options: CskkRuleOptions,
     #[serde(flatten)]
     command: CskkCommandRule,
 }
@@ -127,6 +136,14 @@ impl CskkRule {
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
         let result = toml::from_str::<CskkRule>(&contents)?;
+        if result.options.composition_triggers.is_empty() && !result.conversion.is_empty() {
+            log::warn!(
+                "Rule {:?} has [conversion] entries but no [options] composition_triggers. \
+                 No key will trigger composition mode (▽ mode). \
+                 Add composition_triggers = [\"A\", ..., \"Z\"] to [options].",
+                filepath
+            );
+        }
         Ok(result)
     }
 
@@ -136,6 +153,25 @@ impl CskkRule {
 
     pub(crate) fn get_command_rule(&self) -> &CskkCommandRule {
         &self.command
+    }
+
+    pub(crate) fn get_henkan_trigger_keysyms(&self) -> HashSet<Keysym> {
+        self.options
+            .composition_triggers
+            .iter()
+            .filter_map(|name| {
+                let ks = keysym_from_name(name, xkb::KEYSYM_NO_FLAGS);
+                if ks == Keysym::NoSymbol || ks == Keysym::VoidSymbol {
+                    log::warn!(
+                        "composition_triggers: unrecognised keysym name {:?} — ignored",
+                        name
+                    );
+                    None
+                } else {
+                    Some(ks)
+                }
+            })
+            .collect()
     }
 }
 

--- a/cskk/tests/data/rules/default/rule.toml
+++ b/cskk/tests/data/rules/default/rule.toml
@@ -2,10 +2,18 @@
 name = "default"
 description = "test typing rule"
 
+[options]
+composition_triggers = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+    "quotedbl"
+]
+
 [conversion]
 a = ["", "あ"]
 ba = ["", "ば"]
 tsU = ["", "ちいさいっ"]
+quotedbl = ["", "っ"]
 
 [command]
 # Hiraganaモード時のコマンド

--- a/cskk/tests/shift_symbol_trigger.rs
+++ b/cskk/tests/shift_symbol_trigger.rs
@@ -1,0 +1,113 @@
+mod utils;
+
+use crate::utils::init_test_logger;
+use cskk::dictionary::CskkDictionary;
+use cskk::skk_context_reset_rs;
+use cskk::skk_modes::{CompositionMode, InputMode};
+use cskk::{skk_context_set_composition_mode, skk_context_set_input_mode_rs, CskkContext};
+use std::sync::Arc;
+
+fn test_context_with_data_rules() -> CskkContext {
+    let dict =
+        CskkDictionary::new_static_dict("tests/data/dictionaries/SKK-JISYO.S", "euc-jp", true)
+            .unwrap();
+    CskkContext::new_from_specified_paths(
+        InputMode::Hiragana,
+        CompositionMode::Direct,
+        vec![Arc::new(dict)],
+        "../assets/rule/kana_form.toml",
+        "../assets/rule/ascii_form.toml",
+        "tests/data/rules",
+    )
+}
+
+fn check(
+    context: &mut CskkContext,
+    key_inputs: &str,
+    expected_preedit: &str,
+    expected_output: &str,
+) {
+    skk_context_set_composition_mode(context, CompositionMode::Direct);
+    skk_context_set_input_mode_rs(context, InputMode::Hiragana);
+    context.process_key_events_string(key_inputs);
+    let output = context.poll_output().unwrap_or_default();
+    let preedit = context.get_preedit().unwrap();
+    assert_eq!(
+        preedit, expected_preedit,
+        "preedit mismatch for '{key_inputs}'"
+    );
+    assert_eq!(
+        output, expected_output,
+        "output mismatch for '{key_inputs}'"
+    );
+}
+
+/// (shift quotedbl) → triggers PreComposition and inserts っ as the kana.
+/// This demonstrates the use case of inputting kana with a non-letter key.
+#[test]
+fn shift_quotedbl_enters_precomposition() {
+    init_test_logger();
+    let mut ctx = test_context_with_data_rules();
+    check(&mut ctx, "(shift quotedbl)", "▽っ", "");
+    skk_context_reset_rs(&mut ctx);
+}
+
+/// Bare quotedbl (keysym quotedbl, no explicit shift) also triggers PreComposition
+/// because the trigger check is keysym-based: quotedbl == quotedbl regardless of how
+/// the OS produced it (dedicated key or Shift+').
+#[test]
+fn bare_quotedbl_also_triggers_precomposition() {
+    init_test_logger();
+    let mut ctx = test_context_with_data_rules();
+    check(&mut ctx, "quotedbl", "▽っ", "");
+    skk_context_reset_rs(&mut ctx);
+}
+
+/// (shift at) is NOT in the trigger list → outputs @ raw without entering PreComposition.
+#[test]
+fn non_trigger_shift_symbol_outputs_raw() {
+    init_test_logger();
+    let mut ctx = test_context_with_data_rules();
+    check(&mut ctx, "(shift at)", "", "@");
+    skk_context_reset_rs(&mut ctx);
+}
+
+/// Regression: capital A still enters PreComposition with default trigger set.
+#[test]
+fn capital_a_still_triggers_precomposition() {
+    init_test_logger();
+    let mut ctx = test_context_with_data_rules();
+    check(&mut ctx, "A", "▽あ", "");
+    skk_context_reset_rs(&mut ctx);
+}
+
+/// Regression: tsU (uppercase mid-sequence rule) still converts without mode change.
+#[test]
+#[allow(non_snake_case)]
+fn tsU_sequence_converts_without_mode_change() {
+    init_test_logger();
+    let mut ctx = test_context_with_data_rules();
+    check(&mut ctx, "t s U", "", "ちいさいっ");
+    skk_context_reset_rs(&mut ctx);
+}
+
+/// A followed by (shift quotedbl) — quotedbl acts as an okurigana trigger, advancing past
+/// PreComposition. Depending on the dictionary the engine may enter CompositionSelection
+/// (dict hit) or Register mode (no entry); either proves the okurigana trigger fired.
+#[test]
+fn precomposition_then_quotedbl_trigger_starts_okurigana() {
+    init_test_logger();
+    let mut ctx = test_context_with_data_rules();
+    skk_context_set_composition_mode(&mut ctx, CompositionMode::Direct);
+    skk_context_set_input_mode_rs(&mut ctx, InputMode::Hiragana);
+    ctx.process_key_events_string("A (shift quotedbl)");
+    let preedit = ctx.get_preedit().unwrap();
+    // Okurigana trigger fired: preedit is either 【…】 (Register) or ▼… (CompositionSelection).
+    // In both cases we have left plain PreComposition (▽あ).
+    assert!(
+        preedit.contains('【') || !preedit.starts_with('▽'),
+        "expected okurigana processing after 'A (shift quotedbl)', got: {}",
+        preedit
+    );
+    skk_context_reset_rs(&mut ctx);
+}

--- a/docs/henkan-trigger-extension.md
+++ b/docs/henkan-trigger-extension.md
@@ -1,0 +1,141 @@
+# Henkan Trigger Extension: Configurable Composition Triggers
+
+## Overview
+
+In standard SKK, the capital letters A–Z trigger composition mode (▽ mode /
+PreComposition). When you type `Shift+a`, the OS resolves the keysym to `XK_A`
+and cskk uses that to enter PreComposition and insert `あ`.
+
+This extension makes the trigger set **fully configurable in the rule file**.
+Rule authors list A–Z explicitly, and can add any other keysym (such as
+`quotedbl` for `Shift+'`) as an additional trigger.
+
+## Rule File Syntax
+
+Add an `[options]` section after `[metadata]` and place `composition_triggers`
+inside it:
+
+```toml
+[metadata]
+name = "default"
+description = "My typing rule"
+
+[options]
+composition_triggers = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
+]
+
+[conversion]
+a = ["", "あ"]
+# ...
+```
+
+Keysym names follow the xkbcommon conventions — the same names used in
+`[command]` bindings (e.g. `"A"`, `"quotedbl"`, `"at"`).
+
+If `[options]` or `composition_triggers` is omitted, it defaults to an empty list
+and no key triggers composition mode. The built-in default and AZIK rules both
+include A–Z.
+
+### Adding a Symbol Trigger
+
+To make `Shift+'` (keysym `quotedbl`) enter PreComposition and insert `っ`:
+
+```toml
+[options]
+composition_triggers = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+    "quotedbl"
+]
+
+[conversion]
+# ...
+quotedbl = ["", "っ"]
+```
+
+The rule **must** have a `[conversion]` entry for the keysym so cskk knows
+which kana to insert when the trigger fires.
+
+## How It Works
+
+### Keysyms Encode the Shift State
+
+The OS resolves Shift before cskk sees the key event:
+
+| Key pressed | Keysym sent to cskk | Modifier |
+|-------------|---------------------|----------|
+| `a`         | `XK_a`              | none     |
+| `Shift+a`   | `XK_A`              | SHIFT    |
+| `'`         | `XK_apostrophe`     | none     |
+| `Shift+'`   | `XK_quotedbl`       | SHIFT    |
+| `"` (dedicated key) | `XK_quotedbl` | none |
+
+Because the keysym already encodes which character the user intended, cskk
+checks only `composition_triggers.contains(keysym)` — no separate SHIFT inspection
+is needed.
+
+### Trie Lookup for the Kana
+
+When a trigger fires, cskk looks up the kana to insert:
+
+- **A–Z triggers**: `XK_A` → looks up `XK_a` in the conversion trie (lowercased).
+- **Symbol triggers**: `XK_quotedbl` → looks up `XK_quotedbl` unchanged.
+
+This means a conversion entry like `a = ["", "あ"]` is used for both direct `a`
+input (direct kana conversion) and triggered `A` input (PreComposition + あ).
+Symbol entries like `quotedbl = ["", "っ"]` are used for triggered `quotedbl` input
+only, since the raw `quotedbl` path is skipped for listed triggers.
+
+### Raw Path Suppression for Symbol Triggers
+
+For letter triggers (A–Z), the raw conversion path naturally misses because no
+rule has an uppercase `A` key. For symbol triggers, the raw key and the lookup
+key are the same (`XK_quotedbl` in both cases). Without suppression, cskk would
+convert `っ` directly without entering PreComposition.
+
+The engine suppresses raw-path branches for non-letter keysyms that appear in
+`composition_triggers`, ensuring the trigger path fires instead.
+
+## Limitations
+
+- **No range syntax.** The list must enumerate each keysym name individually.
+  `"A-Z"` is not a shorthand; write all 26 letters explicitly.
+- **Conversion entry required.** A trigger keysym with no `[conversion]` entry
+  will enter PreComposition but insert nothing, then wait for further input.
+- **No "un-shift" mapping.** cskk does not know your keyboard layout, so it
+  cannot derive which key `XK_quotedbl` came from. If you have a dedicated `"`
+  key it produces the same `XK_quotedbl` keysym as `Shift+'` and is treated
+  identically.
+- **Rule is the authority.** Removing a keysym from `composition_triggers` means it
+  never triggers composition mode, regardless of the engine version.
+
+## Example: Custom Rule with Symbol Trigger
+
+```toml
+[metadata]
+name = "custom"
+description = "Default rule plus quotedbl trigger"
+
+[options]
+composition_triggers = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+    "quotedbl"
+]
+
+[conversion]
+a   = ["", "あ"]
+# ... other kana rules ...
+quotedbl = ["", "っ"]
+
+[command]
+# ... command bindings ...
+```
+
+With this rule:
+- `A` → `▽あ` (PreComposition, standard SKK behavior)
+- `Shift+'` or bare `quotedbl` keysym → `▽っ` (PreComposition with っ)
+- `Shift+2` (`XK_at`) → `@` output directly (not in triggers)
+- Plain `'` (`XK_apostrophe`) → direct output (not in triggers)


### PR DESCRIPTION
Introduce composition_triggers in the [options] section of rule.toml. Rule authors enumerate the keysyms (A-Z and optionally symbols like exclam) that trigger PreComposition (▽ mode). Nothing is hardcoded in the engine — the rule file is the single source of truth.

- Add CskkRuleOptions struct with composition_triggers field in rule.rs
- Add to_kana_lookup() and is_upper() helpers to CskkKeyEvent
- Suppress raw-path conversion for non-letter keysyms listed as triggers
- Add composition_triggers (A-Z) to default and azik rule files
- Add integration tests covering symbol trigger, regression for A-Z, and okurigana (shift_symbol_trigger.rs)
- Add docs/henkan-trigger-extension.md