### PR TITLE
fix: update Cargo.lock and add --locked CI check (#312)

### DIFF
--- a/.github/workflows/basic_checks.yaml
+++ b/.github/workflows/basic_checks.yaml
@@ -58,5 +58,7 @@ jobs:
           toolchain: ${{ inputs.toolchain }}
           rustflags: ""
           override: true
+      - name: Verify Cargo.lock is up to date
+        run: cargo check --locked
       - name: Run rust test
         run: cargo test --features capi

--- a/.github/workflows/continuous_testing.yaml
+++ b/.github/workflows/continuous_testing.yaml
@@ -56,6 +56,8 @@ jobs:
           toolchain: ${{ matrix.channel }}
           rustflags: ""
           override: true
+      - name: Verify Cargo.lock is up to date
+        run: cargo check --locked
       - name: Run rust test
         run: cargo test --features capi
   library_test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cskk"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2488,7 +2488,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru_ordered_map"
-version = "3.2.1"
+version = "3.3.0"
 
 [[package]]
 name = "matchers"


### PR DESCRIPTION
## Summary

- Update workspace root `Cargo.lock` to reflect the v3.3.0 version bump (it was stuck at v3.2.1), fixing `cargo check --locked` failure on a fresh clone
- Add `cargo check --locked` step to the `rust_test` job in both `continuous_testing.yaml` and `basic_checks.yaml` to prevent this from regressing silently

## Test plan

- [ ] `cargo check --locked` passes from the workspace root
- [ ] CI `rust_test` jobs in `continuous_testing.yaml` and `basic_checks.yaml` include the new verification step
- [ ] Confirm the new step would have caught this regression (the old committed `Cargo.lock` would fail this check)

Fixes #312